### PR TITLE
store contract source code

### DIFF
--- a/indexer/documents/conv.go
+++ b/indexer/documents/conv.go
@@ -121,7 +121,7 @@ func ConvContractUp(contractAddress string, status, token, codeUrl, code string)
 		VerifiedToken:  token,
 		VerifiedStatus: status,
 		CodeUrl:        codeUrl,
-		Code:           code,
+		SourceCode:     code,
 	}
 }
 

--- a/indexer/documents/conv.go
+++ b/indexer/documents/conv.go
@@ -65,7 +65,7 @@ func ConvTx(txIdx uint64, tx *types.Tx, receipt *types.Receipt, blockDoc *EsBloc
 		BlockId:       blockDoc.Id,
 		Timestamp:     blockDoc.Timestamp,
 		TxIdx:         txIdx,
-		Payload:       string(tx.GetBody().GetPayload()),
+		Payload:       tx.GetBody().GetPayload(),
 		Account:       transaction.EncodeAndResolveAccount(tx.Body.Account, blockDoc.BlockNo),
 		Recipient:     transaction.EncodeAndResolveAccount(tx.Body.Recipient, blockDoc.BlockNo),
 		Amount:        amount.String(),

--- a/indexer/documents/conv.go
+++ b/indexer/documents/conv.go
@@ -90,7 +90,7 @@ func ConvTx(txIdx uint64, tx *types.Tx, receipt *types.Receipt, blockDoc *EsBloc
 // ConvContractCreateTx creates document for token creation
 func ConvContract(txDoc *EsTx, contractAddress []byte) *EsContract {
 
-	byteCode, sourceCode, abi, deployArgs := extractContractCode(txDoc.RawPayload)
+	byteCode, sourceCode, abi, deployArgs := extractContractCode(txDoc.Payload)
 
 	return &EsContract{
 		BaseEsType: &BaseEsType{Id: transaction.EncodeAndResolveAccount(contractAddress, txDoc.BlockNo)},
@@ -140,14 +140,14 @@ func extractContractCode(payload []byte) ([]byte, string, string, string) {
 	return nil, sourceCode, "", deployArgs
 }
 
-func extractByteCode(payload []byte) ([]byte, []byte, []byte) {
+func extractByteCode(payload []byte) ([]byte, string, string) {
 	// read the length of the first section
 	codeAbiLength := binary.BigEndian.Uint32(payload[:4])
 	// read the bytecode length
 	bytecodeLength := binary.BigEndian.Uint32(payload[4:8])
 	// check if the lengths are valid
 	if codeAbiLength > uint32(len(payload)) || bytecodeLength > codeAbiLength {
-		return nil
+		return nil, "", ""
 	}
 	// extract the code+abi and deploy args
 	codeAbi := payload[4:codeAbiLength]
@@ -155,7 +155,7 @@ func extractByteCode(payload []byte) ([]byte, []byte, []byte) {
 	// extract the bytecode and abi
 	bytecode := codeAbi[4:bytecodeLength]
 	abi := codeAbi[4+bytecodeLength:]
-	return bytecode, abi, deployArgs
+	return bytecode, string(abi), string(deployArgs)
 }
 
 func extractSourceCode(payload []byte) (string, string) {

--- a/indexer/documents/documents.go
+++ b/indexer/documents/documents.go
@@ -84,7 +84,11 @@ type EsContract struct {
 	Creator   string    `json:"creator" db:"creator"`
 	BlockNo   uint64    `json:"blockno" db:"blockno"`
 	Timestamp time.Time `json:"ts" db:"ts"`
-	Payload   []byte    `json:"payload" db:"payload"`
+
+	ABI        string    `json:"abi" db:"abi"`
+	ByteCode   []byte    `json:"byte_code" db:"byte_code"`
+	SourceCode string    `json:"source_code" db:"source_code"`
+	DeployArgs string    `json:"deploy_args" db:"deploy_args"`
 
 	VerifiedStatus string `json:"verified_status" db:"verified_status"`
 	VerifiedToken  string `json:"verified_token" db:"verified_token"`
@@ -403,8 +407,17 @@ func InitEsMappings(clusterMode bool) {
 						"ts": {
 							"type": "date"
 						},
-						"payload": {
+						"abi": {
+							"type": "text"
+						},
+						"byte_code": {
 							"type": "binary"
+						},
+						"source_code": {
+							"type": "text"
+						},
+						"deploy_args": {
+							"type": "text"
 						},
 						"verified_status": {
 							"type": "keyword"
@@ -858,8 +871,17 @@ func InitEsMappings(clusterMode bool) {
 						"ts": {
 							"type": "date"
 						},
-						"payload": {
+						"abi": {
+							"type": "text"
+						},
+						"byte_code": {
 							"type": "binary"
+						},
+						"source_code": {
+							"type": "text"
+						},
+						"deploy_args": {
+							"type": "text"
 						},
 						"verified_status": {
 							"type": "keyword"

--- a/indexer/documents/documents.go
+++ b/indexer/documents/documents.go
@@ -93,7 +93,6 @@ type EsContract struct {
 	VerifiedStatus string `json:"verified_status" db:"verified_status"`
 	VerifiedToken  string `json:"verified_token" db:"verified_token"`
 	CodeUrl        string `json:"code_url" db:"code_url"`
-	Code           string `json:"code" db:"code"`
 }
 
 type EsContractUp struct {
@@ -101,7 +100,7 @@ type EsContractUp struct {
 	VerifiedStatus string `json:"verified_status" db:"verified_status"`
 	VerifiedToken  string `json:"verified_token" db:"verified_token"`
 	CodeUrl        string `json:"code_url" db:"code_url"`
-	Code           string `json:"code" db:"code"`
+	SourceCode     string `json:"source_code" db:"source_code"`
 }
 
 // EsEvent is a contract-event mapping stored in the database
@@ -427,9 +426,6 @@ func InitEsMappings(clusterMode bool) {
 						},
 						"code_url": {
 							"type": "keyword"
-						},
-						"code": {
-							"type": "text"
 						}
 					}
 				}
@@ -891,9 +887,6 @@ func InitEsMappings(clusterMode bool) {
 						},
 						"code_url": {
 							"type": "keyword"
-						},
-						"code": {
-							"type": "text"
 						}
 					}
 				}

--- a/indexer/documents/documents.go
+++ b/indexer/documents/documents.go
@@ -59,7 +59,7 @@ type EsTx struct {
 	BlockId       string        `json:"block_id" db:"block_id"`
 	Timestamp     time.Time     `json:"ts" db:"ts"`
 	TxIdx         uint64        `json:"tx_idx" db:"tx_idx"`
-	Payload       string        `json:"payload" db:"payload"`
+	Payload       []byte        `json:"payload" db:"payload"`
 	Account       string        `json:"from" db:"from"`
 	Recipient     string        `json:"to" db:"to"`
 	Amount        string        `json:"amount" db:"amount"`             // string of BigInt
@@ -84,7 +84,7 @@ type EsContract struct {
 	Creator   string    `json:"creator" db:"creator"`
 	BlockNo   uint64    `json:"blockno" db:"blockno"`
 	Timestamp time.Time `json:"ts" db:"ts"`
-	Payload   string    `json:"payload" db:"payload"`
+	Payload   []byte    `json:"payload" db:"payload"`
 
 	VerifiedStatus string `json:"verified_status" db:"verified_status"`
 	VerifiedToken  string `json:"verified_token" db:"verified_token"`
@@ -327,7 +327,7 @@ func InitEsMappings(clusterMode bool) {
 							"type": "long"
 						},
 						"payload": {
-							"type": "text"
+							"type": "binary"
 						},
 						"from": {
 							"type": "keyword"
@@ -404,7 +404,7 @@ func InitEsMappings(clusterMode bool) {
 							"type": "date"
 						},
 						"payload": {
-							"type": "text"
+							"type": "binary"
 						},
 						"verified_status": {
 							"type": "keyword"
@@ -782,7 +782,7 @@ func InitEsMappings(clusterMode bool) {
 							"type": "long"
 						},
 						"payload": {
-							"type": "text"
+							"type": "binary"
 						},
 						"from": {
 							"type": "keyword"
@@ -859,7 +859,7 @@ func InitEsMappings(clusterMode bool) {
 							"type": "date"
 						},
 						"payload": {
-							"type": "text"
+							"type": "binary"
 						},
 						"verified_status": {
 							"type": "keyword"

--- a/indexer/miner.go
+++ b/indexer/miner.go
@@ -114,10 +114,6 @@ func (ns *Indexer) MinerTx(txIdx uint64, info BlockInfo, blockDoc *doc.EsBlock, 
 		tokenDoc := doc.ConvToken(txDoc, receipt.ContractAddress, tType, name, symbol, decimals, supply, supplyFloat)
 		ns.addToken(tokenDoc)
 
-		// Add Contract Doc
-		contractDoc := doc.ConvContract(txDoc, receipt.ContractAddress)
-		ns.addContract(info.Type, contractDoc)
-
 		ns.log.Info().Str("contract", transaction.EncodeAccount(receipt.ContractAddress)).Msg("Token created ( Policy 2 )")
 	}
 
@@ -179,7 +175,7 @@ func (ns *Indexer) MinerEventByName(info BlockInfo, blockDoc *doc.EsBlock, txDoc
 		ns.addAccountTokens(info.Type, accountTokensDoc)
 
 		// Add Contract Doc
-		contractDoc := doc.ConvContract(txDoc, contractAddress)
+		contractDoc := doc.ConvInternalContract(txDoc, contractAddress)
 		ns.addContract(info.Type, contractDoc)
 
 		ns.log.Info().Str("contract", transaction.EncodeAccount(contractAddress)).Msg("Token created ( Policy 1 )")


### PR DESCRIPTION
These changes extract the source-code from the tx payload after hardfork 4, and bytecode + ABI before that

The payload (from tx) is now stored as raw bytes on the database

The contract doc now contains different fields, and the byteCode field is also stored as raw bytes