### PR TITLE
Skip local compiler test while running github actions.

### DIFF
--- a/lua_compiler/compiler_test.go
+++ b/lua_compiler/compiler_test.go
@@ -2,6 +2,7 @@ package lua_compiler
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -18,6 +19,12 @@ func TestGetData(t *testing.T) {
 }
 
 func TestLocalCompile(t *testing.T) {
+	// check if aergoluac exists in PATH
+	_, err := exec.LookPath("aergoluac")
+	if err != nil {
+		t.Skip("Skip local compile test because aergoluac binary not found in PATH")
+	}
+
 	code := readLuaCode("type_arrayarg.lua")
 	byteCodeABI, err := CompileCodeLocal(code)
 	require.NoError(t, err)


### PR DESCRIPTION
The local compilation test is skipped when no aergoluac binary is found. 

There is another option; compile aergoluac inside github action, but I think it isn’t worth the effort. Therefore, I suggest that local compilation test to the developer's responsibility; run only his own machine when needed.
