### PR TITLE
use bulk insertions for internal_operations and contract_call

### DIFF
--- a/indexer/bulk.go
+++ b/indexer/bulk.go
@@ -52,6 +52,8 @@ func (b *Bulk) StartBulkChannel() {
 	b.BChannel.Contract = make(chan ChanInfo)
 	b.BChannel.TokenTransfer = make(chan ChanInfo)
 	b.BChannel.AccTokens = make(chan ChanInfo)
+	b.BChannel.InternalOps = make(chan ChanInfo)
+	b.BChannel.ContractCall = make(chan ChanInfo)
 	b.SynDone = make(chan bool)
 
 	// Start bulk indexers for each index
@@ -61,6 +63,8 @@ func (b *Bulk) StartBulkChannel() {
 	go b.BulkIndexer(b.BChannel.Contract, b.idxer.indexNamePrefix+"contract", b.bulkSize, b.batchTime, false)
 	go b.BulkIndexer(b.BChannel.TokenTransfer, b.idxer.indexNamePrefix+"token_transfer", b.bulkSize, b.batchTime, false)
 	go b.BulkIndexer(b.BChannel.AccTokens, b.idxer.indexNamePrefix+"account_tokens", b.bulkSize, b.batchTime, false)
+	go b.BulkIndexer(b.BChannel.InternalOps, b.idxer.indexNamePrefix+"internal_operations", b.bulkSize, b.batchTime, false)
+	go b.BulkIndexer(b.BChannel.ContractCall, b.idxer.indexNamePrefix+"contract_call", b.bulkSize, b.batchTime, false)
 
 	// Start multiple miners
 	GrpcClients := make([]*client.AergoClientController, b.grpcNum)
@@ -100,6 +104,8 @@ func (b *Bulk) StopBulkChannel() {
 	b.BChannel.Contract <- ChanInfo{ChanType_StopBulk, nil}
 	b.BChannel.TokenTransfer <- ChanInfo{ChanType_StopBulk, nil}
 	b.BChannel.AccTokens <- ChanInfo{ChanType_StopBulk, nil}
+	b.BChannel.InternalOps <- ChanInfo{ChanType_StopBulk, nil}
+	b.BChannel.ContractCall <- ChanInfo{ChanType_StopBulk, nil}
 
 	// Close bulk channels
 	close(b.BChannel.Block)
@@ -108,6 +114,8 @@ func (b *Bulk) StopBulkChannel() {
 	close(b.BChannel.Contract)
 	close(b.BChannel.TokenTransfer)
 	close(b.BChannel.AccTokens)
+	close(b.BChannel.InternalOps)
+	close(b.BChannel.ContractCall)
 	close(b.SynDone)
 
 	b.idxer.log.Info().Msg("Stop Bulk Indexer")
@@ -153,8 +161,10 @@ func (b *Bulk) BulkIndexer(docChannel chan ChanInfo, indexName string, bulkSize 
 			b.BChannel.Contract <- ChanInfo{ChanType_Commit, nil}
 			b.BChannel.TokenTransfer <- ChanInfo{ChanType_Commit, nil}
 			b.BChannel.AccTokens <- ChanInfo{ChanType_Commit, nil}
+			b.BChannel.InternalOps <- ChanInfo{ChanType_Commit, nil}
+			b.BChannel.ContractCall <- ChanInfo{ChanType_Commit, nil}
 
-			for i := 0; i < 5; i++ {
+			for i := 0; i < 7; i++ {
 				<-b.SynDone
 			}
 		}

--- a/indexer/define.go
+++ b/indexer/define.go
@@ -36,6 +36,8 @@ type ChanInfoType struct {
 	Contract      chan ChanInfo
 	TokenTransfer chan ChanInfo
 	AccTokens     chan ChanInfo
+	InternalOps   chan ChanInfo
+	ContractCall  chan ChanInfo
 }
 
 type VerifiedStatus string

--- a/indexer/dto.go
+++ b/indexer/dto.go
@@ -51,17 +51,25 @@ func (ns *Indexer) addContract(blockType BlockType, contractDoc *doc.EsContract)
 	}
 }
 
-func (ns *Indexer) addInternalOperations(internalOpsDoc *doc.EsInternalOperations) {
-	err := ns.db.Insert(internalOpsDoc, ns.indexNamePrefix+"internal_operations")
-	if err != nil {
-		ns.log.Error().Err(err).Str("Id", internalOpsDoc.Id).Str("method", "insertInternalOperations").Msg("error while insert")
+func (ns *Indexer) addInternalOperations(blockType BlockType, internalOpsDoc *doc.EsInternalOperations) {
+	if blockType == BlockType_Bulk {
+		ns.bulk.BChannel.InternalOps <- ChanInfo{ChanType_Add, internalOpsDoc}
+	} else {
+		err := ns.db.Insert(internalOpsDoc, ns.indexNamePrefix+"internal_operations")
+		if err != nil {
+			ns.log.Error().Err(err).Str("Id", internalOpsDoc.Id).Str("method", "insertInternalOperations").Msg("error while insert")
+		}
 	}
 }
 
-func (ns *Indexer) addContractCall(contractCallDoc *doc.EsContractCall) {
-	err := ns.db.Insert(contractCallDoc, ns.indexNamePrefix+"contract_call")
-	if err != nil {
-		ns.log.Error().Err(err).Str("Id", contractCallDoc.Id).Str("method", "insertContractCall").Msg("error while insert")
+func (ns *Indexer) addContractCall(blockType BlockType, contractCallDoc *doc.EsContractCall) {
+	if blockType == BlockType_Bulk {
+		ns.bulk.BChannel.ContractCall <- ChanInfo{ChanType_Add, contractCallDoc}
+	} else {
+		err := ns.db.Insert(contractCallDoc, ns.indexNamePrefix+"contract_call")
+		if err != nil {
+			ns.log.Error().Err(err).Str("Id", contractCallDoc.Id).Str("method", "insertContractCall").Msg("error while insert")
+		}
 	}
 }
 

--- a/indexer/miner.go
+++ b/indexer/miner.go
@@ -94,6 +94,7 @@ type CallInfo struct {
 	TxDoc       *doc.EsTx
 	CallIdx     uint64
 	SendIdx     uint64
+	BlockType   BlockType
 }
 
 func (ns *Indexer) MinerTx(txIdx uint64, info BlockInfo, blockDoc *doc.EsBlock, tx *types.Tx, internalOps *InternalOperations, MinerGRPC *client.AergoClientController) {
@@ -141,11 +142,12 @@ func (ns *Indexer) MinerTx(txIdx uint64, info BlockInfo, blockDoc *doc.EsBlock, 
 			TxDoc:       txDoc,
 			CallIdx:     1,
 			SendIdx:     0,
+			BlockType:   info.Type,
 		}
 		// register external call
 		txCall := internalOps.Call
 		txCallDoc := doc.ConvContractCall(callInfo.BlockHeight, callInfo.Timestamp, callInfo.TxHash, callInfo.TxIdx, callInfo.CallIdx, sender, txCall.Contract, txCall.Function, txCall.Args, txCall.Amount, txDoc.Status == "ERROR")
-		ns.addContractCall(txCallDoc)
+		ns.addContractCall(info.Type, txCallDoc)
 		// Process internal operations
 		if len(txCall.Operations) > 0 {
 			ns.MinerTxInternalOps(&callInfo, &txCall)
@@ -212,7 +214,7 @@ func (ns *Indexer) MinerTxInternalOps(callInfo *CallInfo, outerCall *InternalCal
 		Str("operations", string(jsonOperations)).Msg("Processing internal operations")
 	// save to db
 	internalOpsDoc := doc.ConvInternalOperations(callInfo.TxHash, string(jsonOperations))
-	ns.addInternalOperations(internalOpsDoc)
+	ns.addInternalOperations(callInfo.BlockType, internalOpsDoc)
 
 	// process each operation from this contract
 	for _, operation := range outerCall.Operations {
@@ -240,7 +242,7 @@ func (ns *Indexer) MinerContractInternalOp(callInfo *CallInfo, contract string, 
 
 		// register internal call
 		internalCallDoc := doc.ConvContractCall(callInfo.BlockHeight, callInfo.Timestamp, callInfo.TxHash, callInfo.TxIdx, callInfo.CallIdx, contract, internalCall.Contract, internalCall.Function, internalCall.Args, internalCall.Amount, internalOpReverted)
-		ns.addContractCall(internalCallDoc)
+		ns.addContractCall(callInfo.BlockType, internalCallDoc)
 
 		// process each operation from this internal call
 		for _, nestedOperation := range internalCall.Operations {


### PR DESCRIPTION
this will group many insertions into a batch, to increase performance and decrease number of individual HTTP requests to elasticseearch